### PR TITLE
Remove command to uninstall GCC

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ sudo apt-get install doxygen
 remove all gcc related stuff, then following the instruction in [this](http://askubuntu.com/questions/466651/how-do-i-use-the-latest-gcc-on-ubuntu) forum:
 ```
 #!bash
-sudo apt-get remove gcc-*
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 sudo apt-get update
 sudo apt-get install gcc-4.9 g++-4.9


### PR DESCRIPTION
Removing gcc will likely break the machine and according to the forum page is not necessary to install the gcc 4.9
